### PR TITLE
favicon is not bundled into expressjs4

### DIFF
--- a/anchor/anchor.js
+++ b/anchor/anchor.js
@@ -41,6 +41,7 @@ var io = require('socket.io').listen(server);
 var fs = require('fs');
 var redis = require('node-redis');
 var redisClient = redis.createClient(REDIS_PORT, REDIS_HOST);
+var favicon = require('serve-favicon');
 
 /**
  * define global variables
@@ -111,14 +112,14 @@ app.use('/img', express.static(ROOT_DIR + '/img'));
 app.use('/js', express.static(ROOT_DIR + '/js'));
 app.use('/css', express.static(ROOT_DIR + '/css'));
 app.use('/data', express.static(ROOT_DIR + '/data'));
-app.use(express.favicon(ROOT_DIR + '/img/favicon.ico'));
+app.use(favicon(ROOT_DIR + '/img/favicon.ico'));
 
 /**
  * Setup one generic route that always points to the index.html
  */
 app.get('/*', function(req, res) {
 	parseLayout(req.url);
-	res.sendfile(__dirname + '/views/index.html');
+	res.sendFile(__dirname + '/views/index.html');
 });
 
 

--- a/anchor/package.json
+++ b/anchor/package.json
@@ -11,6 +11,7 @@
     "json-socket": ">=0.1.2",
     "socket.io": "*",
     "express": "*",
+    "serve-favicon": "*",
     "node-redis": "0.1.x"
   }
 }


### PR DESCRIPTION
Since expressjs4 the favicon module is not bundled anymore and
it seems the replacement is the serve-favicon module.
https://github.com/expressjs/serve-favicon

Without this fix the anchor won't start.

Furthermore, the sendfile method is deprecated in expressjs4.
